### PR TITLE
Add macOS and Windows builds, fix deprecated directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ config.yaml
 
 tmp/
 bin/
+
+# GoReleaser
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,27 +1,20 @@
 version: 2
-before:
-  hooks:
-    - go mod tidy
 builds:
   - env:
       - CGO_ENABLED=0
-      - PACKAGE=github.com/cterence/tailout
-    ldflags:
-      - -X ${PACKAGE}/internal/version.Version=${VERSION}
-      - -X ${PACKAGE}/internal/version.CommitHash=${COMMIT_HASH}
-      - -X ${PACKAGE}/internal/version.BuildTimestamp=${BUILD_TIMESTAMP}
     goos:
       - linux
-    main: ./
+      - darwin
+      - windows
     binary: tailout
 archives:
   - format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
Build settings updates:

* `ldflags`  are not used.
* Added builds for macOS and Windows.

Updated deprecated settings to fix:

```
• DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
• DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```