### PR TITLE
Fix hostname and IP retrieval

### DIFF
--- a/tailout/connect.go
+++ b/tailout/connect.go
@@ -28,7 +28,7 @@ func (app *App) Connect(args []string) error {
 
 	tailoutDevices, err := internal.GetActiveNodes(apiClient)
 	if err != nil {
-		fmt.Errorf("failed to get active nodes: %w", err)
+		return fmt.Errorf("failed to get active nodes: %w", err)
 	}
 
 	if len(args) != 0 {

--- a/tailout/status.go
+++ b/tailout/status.go
@@ -53,7 +53,12 @@ func (app *App) Status() error {
 	}
 
 	// Query for the public IP address of this Node
-	resp, err := http.Get("https://ifconfig.me")
+	httpClient := &http.Client{}
+	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, "https://ifconfig.me/ip", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to get public IP: %w", err)
 	}


### PR DESCRIPTION
- The `INSTANCE_ID` wasn't always retrieved correctly, passing a `TOKEN` to always authenticate.
- Added `nodeName` as name of the instance.
- Fixed the query to get current IP. It was returning the HTLM of the page instead of the IP address.